### PR TITLE
Multiple changes to reduce size

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,16 +1,25 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 5257,
-    "minified": 3527,
-    "gzipped": 1088
+    "bundled": 4055,
+    "minified": 2585,
+    "gzipped": 908
   },
   "dist/index.esm.js": {
-    "bundled": 4692,
-    "minified": 3077,
-    "gzipped": 997,
+    "bundled": 3654,
+    "minified": 2223,
+    "gzipped": 821,
     "treeshaked": {
-      "rollup": 2009,
-      "webpack": 3088
+      "rollup": 1544,
+      "webpack": 2286
+    }
+  },
+  "dist/test.test.js": {
+    "bundled": 3650,
+    "minified": 2219,
+    "gzipped": 816,
+    "treeshaked": {
+      "rollup": 1540,
+      "webpack": 2282
     }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,16 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 4055,
-    "minified": 2585,
-    "gzipped": 908
+    "bundled": 4556,
+    "minified": 2831,
+    "gzipped": 994
   },
-  "dist/index.esm.js": {
-    "bundled": 3654,
-    "minified": 2223,
-    "gzipped": 821,
+  "dist/HeadTag.js": {
+    "bundled": 3213,
+    "minified": 1926,
+    "gzipped": 779,
     "treeshaked": {
-      "rollup": 1544,
-      "webpack": 2286
-    }
-  },
-  "dist/test.test.js": {
-    "bundled": 3650,
-    "minified": 2219,
-    "gzipped": 816,
-    "treeshaked": {
-      "rollup": 1540,
-      "webpack": 2282
+      "rollup": 1170,
+      "webpack": 1851
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,41 +299,6 @@
         }
       }
     },
-    "@babel/helper-builder-react-jsx": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.47.tgz",
-      "integrity": "sha512-oBGX/MyT4kNGuINK2k/KLHD77Ih1oTROtoxnV3uAPS9rLYhmZn3W8qy2L4bbyMwQ89nVSM427b0bTTXUEEReXA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.47",
-        "esutils": "^2.0.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
-          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.5",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
-    },
     "@babel/helper-call-delegate": {
       "version": "7.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.47.tgz",
@@ -2154,16 +2119,6 @@
         }
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.47.tgz",
-      "integrity": "sha512-ujUjQUyTxUWHfixRD7Y5Nm8VCgHSf6YgbM37LEnojKp5lPahZO42qJfDty+Kh0tEanpI5H8BLPkJbFSzx6TNEw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.47",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
-      }
-    },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.47.tgz",
@@ -2750,6 +2705,23 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0-beta.51.tgz",
+      "integrity": "sha1-DVaj4tiwbZ3mxlGYNaPgKESOE7g=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.51.tgz",
+          "integrity": "sha1-D2pfK20cZERBP4+rYJQNebY8IDE=",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.47.tgz",
@@ -2812,17 +2784,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.47.tgz",
-      "integrity": "sha512-HGian2BbCsyAqs6LntVVRpjXG9TkzhHfTynjUoMxOFL29doKEy/0s96SMvmbBSR/wMRKMd1OPvCiEYYxqZtr3g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-builder-react-jsx": "7.0.0-beta.47",
-        "@babel/helper-plugin-utils": "7.0.0-beta.47",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -3015,6 +2976,18 @@
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.47.tgz",
+          "integrity": "sha512-ujUjQUyTxUWHfixRD7Y5Nm8VCgHSf6YgbM37LEnojKp5lPahZO42qJfDty+Kh0tEanpI5H8BLPkJbFSzx6TNEw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "7.0.0-beta.47",
+            "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
+          }
+        }
       }
     },
     "@babel/preset-react": {
@@ -3029,6 +3002,52 @@
         "@babel/plugin-transform-react-jsx": "7.0.0-beta.47",
         "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.47",
         "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-builder-react-jsx": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.47.tgz",
+          "integrity": "sha512-oBGX/MyT4kNGuINK2k/KLHD77Ih1oTROtoxnV3uAPS9rLYhmZn3W8qy2L4bbyMwQ89nVSM427b0bTTXUEEReXA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.47",
+            "esutils": "^2.0.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.47.tgz",
+          "integrity": "sha512-HGian2BbCsyAqs6LntVVRpjXG9TkzhHfTynjUoMxOFL29doKEy/0s96SMvmbBSR/wMRKMd1OPvCiEYYxqZtr3g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-react-jsx": "7.0.0-beta.47",
+            "@babel/helper-plugin-utils": "7.0.0-beta.47",
+            "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "@babel/preset-stage-3": {
@@ -3045,6 +3064,18 @@
         "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.47",
         "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.47",
         "@babel/plugin-syntax-import-meta": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.47.tgz",
+          "integrity": "sha512-ujUjQUyTxUWHfixRD7Y5Nm8VCgHSf6YgbM37LEnojKp5lPahZO42qJfDty+Kh0tEanpI5H8BLPkJbFSzx6TNEw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "7.0.0-beta.47",
+            "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
+          }
+        }
       }
     },
     "@babel/runtime": {
@@ -4355,6 +4386,80 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buble": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.3.tgz",
+      "integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.4.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "acorn-jsx": "^4.1.1",
+        "chalk": "^2.3.1",
+        "magic-string": "^0.22.4",
+        "minimist": "^1.2.0",
+        "os-homedir": "^1.0.1",
+        "vlq": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+          "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.0.3"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "vlq": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+          "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
+          "dev": true
+        }
       }
     },
     "buffer": {
@@ -6286,7 +6391,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -6337,7 +6443,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -6352,6 +6459,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -6360,6 +6468,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6368,6 +6477,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -6376,7 +6486,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -6393,12 +6504,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6406,17 +6519,20 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -6462,7 +6578,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -6488,7 +6605,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -6510,12 +6628,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -6571,6 +6691,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6583,7 +6704,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -6622,7 +6744,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -6639,6 +6762,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -6647,7 +6771,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -6659,6 +6784,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6672,7 +6798,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -6745,12 +6872,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -6759,6 +6888,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6766,12 +6896,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6824,7 +6956,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6842,6 +6975,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6871,7 +7005,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -6882,7 +7017,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -6920,6 +7056,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -6964,6 +7101,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -6971,7 +7109,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -7029,6 +7168,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7039,6 +7179,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -7053,6 +7194,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7067,6 +7209,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -7122,7 +7265,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -7151,7 +7295,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12098,6 +12243,16 @@
         }
       }
     },
+    "rollup-plugin-buble": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-buble/-/rollup-plugin-buble-0.19.2.tgz",
+      "integrity": "sha512-dxK0prR8j/7qhI2EZDz/evKCRuhuZMpRlUGPrRWmpg5/2V8tP1XFW+Uk0WfxyNgFfJHvy0GmxnJSTb5dIaNljQ==",
+      "dev": true,
+      "requires": {
+        "buble": "^0.19.2",
+        "rollup-pluginutils": "^2.0.1"
+      }
+    },
     "rollup-plugin-replace": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
@@ -12554,7 +12709,8 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -12579,7 +12735,8 @@
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3078,27 +3078,6 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.47.tgz",
-      "integrity": "sha512-3IaakAC5B4bHJ0aCUKVw0pt+GruavdgWDFbf7TfKh7ZJ8yQuUp7af7MNwf3e+jH8776cjqYmMO1JNDDAE9WfrA==",
-      "requires": {
-        "core-js": "^2.5.3",
-        "regenerator-runtime": "^0.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.6",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.47",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0-beta.47",
+    "@babel/plugin-transform-object-assign": "^7.0.0-beta.51",
     "@babel/plugin-transform-runtime": "^7.0.0-beta.47",
     "@babel/preset-env": "^7.0.0-beta.47",
     "@babel/preset-react": "^7.0.0-beta.47",
@@ -72,6 +73,7 @@
     "react-test-renderer": "^16.3.2",
     "rollup": "^0.59.0",
     "rollup-plugin-babel": "^4.0.0-beta.4",
+    "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-size-snapshot": "^0.4.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,5 @@
     "tabWidth": 2,
     "printWidth": 100
   },
-  "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.47"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SSR-ready Document Head management for React 16+",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,27 +6,25 @@ import pkg from './package.json';
 const input = './src/index.js';
 
 // treat as external everything from node_modules
-const external = id => !id.startsWith('/') && !id.startsWith('.');
+// const external = id => !id.startsWith('/') && !id.startsWith('.');
 
-const getBabelOptions = ({ useESModules }) => ({
+const babelOptions = {
   babelrc: false,
-  runtimeHelpers: true,
-  plugins: [
-    '@babel/plugin-transform-object-assign',
-    ['@babel/transform-runtime', { polyfill: false, useESModules }],
-  ],
-});
+  plugins: ['@babel/plugin-transform-object-assign'],
+};
+
+const bubleOptions = {
+  objectAssign: 'Object.assign',
+};
+
+const external = ['react', 'react-dom', 'prop-types'];
 
 export default [
   {
     input,
     output: { file: pkg.main, format: 'cjs', exports: 'named' },
     external,
-    plugins: [
-      buble({ objectAssign: 'Object.assign' }),
-      babel(getBabelOptions({ useESModules: false })),
-      sizeSnapshot(),
-    ],
+    plugins: [buble(bubleOptions), babel(babelOptions), sizeSnapshot()],
   },
   {
     input,
@@ -35,10 +33,6 @@ export default [
       format: 'es',
     },
     external,
-    plugins: [
-      buble({ objectAssign: 'Object.assign' }),
-      babel(getBabelOptions({ useESModules: true })),
-      sizeSnapshot(),
-    ],
+    plugins: [buble(bubleOptions), babel(babelOptions), sizeSnapshot()],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from 'rollup-plugin-babel';
+import buble from 'rollup-plugin-buble';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
 
@@ -8,8 +9,12 @@ const input = './src/index.js';
 const external = id => !id.startsWith('/') && !id.startsWith('.');
 
 const getBabelOptions = ({ useESModules }) => ({
+  babelrc: false,
   runtimeHelpers: true,
-  plugins: [['@babel/transform-runtime', { polyfill: false, useESModules }]],
+  plugins: [
+    '@babel/plugin-transform-object-assign',
+    ['@babel/transform-runtime', { polyfill: false, useESModules }],
+  ],
 });
 
 export default [
@@ -17,13 +22,23 @@ export default [
     input,
     output: { file: pkg.main, format: 'cjs', exports: 'named' },
     external,
-    plugins: [babel(getBabelOptions({ useESModules: false })), sizeSnapshot()],
+    plugins: [
+      buble({ objectAssign: 'Object.assign' }),
+      babel(getBabelOptions({ useESModules: false })),
+      sizeSnapshot(),
+    ],
   },
-
   {
     input,
-    output: { file: pkg.module, format: 'es' },
+    output: {
+      file: pkg.module,
+      format: 'es',
+    },
     external,
-    plugins: [babel(getBabelOptions({ useESModules: true })), sizeSnapshot()],
+    plugins: [
+      buble({ objectAssign: 'Object.assign' }),
+      babel(getBabelOptions({ useESModules: true })),
+      sizeSnapshot(),
+    ],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,10 @@
+import { resolve } from 'path';
 import babel from 'rollup-plugin-babel';
 import buble from 'rollup-plugin-buble';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
 
 const input = './src/index.js';
-
-// treat as external everything from node_modules
-// const external = id => !id.startsWith('/') && !id.startsWith('.');
 
 const babelOptions = {
   babelrc: false,
@@ -17,13 +15,11 @@ const bubleOptions = {
   objectAssign: 'Object.assign',
 };
 
-const external = ['react', 'react-dom', 'prop-types'];
-
 export default [
   {
     input,
     output: { file: pkg.main, format: 'cjs', exports: 'named' },
-    external,
+    external: ['react', 'react-dom', 'prop-types'],
     plugins: [buble(bubleOptions), babel(babelOptions), sizeSnapshot()],
   },
   {
@@ -32,7 +28,32 @@ export default [
       file: pkg.module,
       format: 'es',
     },
-    external,
+    external: [
+      'react',
+      'react-dom',
+      'prop-types',
+      resolve('./src/HeadTag.js'),
+      resolve('./src/HeadCollector.js'),
+    ],
+    plugins: [buble(bubleOptions), babel(babelOptions)],
+  },
+  {
+    input: './src/HeadCollector.js',
+    output: {
+      file: 'dist/HeadCollector.js',
+      format: 'es',
+    },
+    external: ['react', 'prop-types'],
+    plugins: [buble(bubleOptions)],
+  },
+  {
+    input: './src/HeadTag.js',
+    output: {
+      file: 'dist/HeadTag.js',
+      format: 'es',
+    },
+    external: ['react', 'react-dom', 'prop-types'],
+    // TODO: OMG WTF IS THIS SHIT?! Make sure no object.assign is left!
     plugins: [buble(bubleOptions), babel(babelOptions), sizeSnapshot()],
   },
 ];

--- a/src/HeadCollector.js
+++ b/src/HeadCollector.js
@@ -2,15 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export default class HeadCollector extends Component {
-  static propTypes = {
-    headTags: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-    children: PropTypes.node.isRequired,
-  };
-
-  static childContextTypes = {
-    reactHeadTags: PropTypes.object,
-  };
-
   getChildContext() {
     return {
       reactHeadTags: {
@@ -23,3 +14,12 @@ export default class HeadCollector extends Component {
     return React.Children.only(this.props.children);
   }
 }
+
+HeadCollector.propTypes = {
+  headTags: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  children: PropTypes.node.isRequired,
+};
+
+HeadCollector.childContextTypes = {
+  reactHeadTags: PropTypes.object,
+};

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -4,22 +4,6 @@ import PropTypes from 'prop-types';
 import buildSelector from './buildSelector';
 
 export default class HeadTag extends Component {
-  static contextTypes = {
-    reactHeadTags: PropTypes.object,
-  };
-
-  static propTypes = {
-    tag: PropTypes.string,
-  };
-
-  static defaultProps = {
-    tag: 'meta',
-  };
-
-  state = {
-    canUseDOM: false,
-  };
-
   componentDidMount() {
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ canUseDOM: true });
@@ -50,3 +34,15 @@ export default class HeadTag extends Component {
     return null;
   }
 }
+
+HeadTag.contextTypes = {
+  reactHeadTags: PropTypes.object,
+};
+
+HeadTag.propTypes = {
+  tag: PropTypes.string,
+};
+
+HeadTag.defaultProps = {
+  tag: 'meta',
+};

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import buildSelector from './buildSelector';
 
 export default class HeadTag extends Component {
+  constructor() {
+    super();
+    this.state = {
+      canUseDOM: false,
+    };
+  }
   componentDidMount() {
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ canUseDOM: true });
@@ -19,7 +25,6 @@ export default class HeadTag extends Component {
 
   render() {
     const { tag: Tag, ...rest } = this.props;
-
     if (this.state.canUseDOM) {
       const Comp = <Tag {...rest} />;
       return ReactDOM.createPortal(Comp, document.head);
@@ -34,14 +39,19 @@ export default class HeadTag extends Component {
     return null;
   }
 }
+// eslint-disable-next-line no-unused-expressions
+process.env.NODE_ENV !== 'production'
+  ? (HeadTag.contextTypes = {
+      reactHeadTags: PropTypes.object,
+    })
+  : undefined;
 
-HeadTag.contextTypes = {
-  reactHeadTags: PropTypes.object,
-};
-
-HeadTag.propTypes = {
-  tag: PropTypes.string,
-};
+// eslint-disable-next-line no-unused-expressions
+process.env.NODE_ENV !== 'production'
+  ? (HeadTag.propTypes = {
+      tag: PropTypes.string,
+    })
+  : undefined;
 
 HeadTag.defaultProps = {
   tag: 'meta',

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -56,3 +56,11 @@ process.env.NODE_ENV !== 'production'
 HeadTag.defaultProps = {
   tag: 'meta',
 };
+
+export const Title = props => <HeadTag tag="title" {...props} />;
+
+export const Style = props => <HeadTag tag="style" {...props} />;
+
+export const Meta = props => <HeadTag tag="meta" {...props} />;
+
+export const Link = props => <HeadTag tag="link" {...props} />;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,2 @@
-import React from 'react';
-import HeadTag from './HeadTag';
-
-export const Title = props => <HeadTag tag="title" {...props} />;
-
-export const Style = props => <HeadTag tag="style" {...props} />;
-
-export const Meta = props => <HeadTag tag="meta" {...props} />;
-
-export const Link = props => <HeadTag tag="link" {...props} />;
-
+export { default, Title, Style, Meta, Link } from './HeadTag';
 export { default as HeadCollector } from './HeadCollector';
-
-export default HeadTag;


### PR DESCRIPTION
Hi!

I took it upon myself to make this package as small as it could possibly become.
These are the changes I made:

* Use [buble](https://github.com/Rich-Harris/buble) for transpiling instead of babel (except for polyfilling object.assign which is still done with babel, since buble doesn't do it by default)
* Removing the use of `@babel/runtime`. This package seems to have a glitch where it includes a bunch of unnecessary polyfills into the final application bundle (see screenshot below)
* Remove prop-types in production builds, but NOT in dev builds - thereby keeping dev experience the same.
* Make HeadCollector tree shakable when using es modules. Obviously this class is only used on the server so it doesn't ever need to be in a client-side javascript bundle. Nonetheless webpack tree shaking is kind of weird so I had to change the folder structure a little bit.

I made some benchmarking and when comparing to the current 2.1.0 (not current master) the total savings are around 3.4 kb minified but **not** gzipped and only about 330 bytes gzipped. This benchmark was made on a boilerplate project with some common libraries included.

Note that using the current master results in a *much larger* build size, because it includes `@babel/runtime` which as mentioned earlier seems to cause bundle size bloat because of included a bunch polyfills (?!).