### PR TITLE
Remove prop-types in production

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,6 +4,7 @@ module.exports = {
     ['@babel/stage-3', { loose: true }],
     '@babel/react',
   ],
+  plugins: [['transform-react-remove-prop-types', { mode: 'wrap' }]],
   env: {
     test: {
       plugins: ['@babel/transform-modules-commonjs'],

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 4129,
-    "minified": 2600,
-    "gzipped": 930
+    "bundled": 4219,
+    "minified": 2678,
+    "gzipped": 960
   },
   "dist/index.esm.js": {
-    "bundled": 3660,
-    "minified": 2216,
-    "gzipped": 830,
+    "bundled": 3750,
+    "minified": 2294,
+    "gzipped": 861,
     "treeshaked": {
       "rollup": {
-        "code": 1511,
+        "code": 1445,
         "import_statements": 260
       },
       "webpack": {
-        "code": 2731
+        "code": 2659
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4418,6 +4418,12 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz",
+      "integrity": "sha1-Mxz8BQmagII4MR14MZwnRg1IEYk=",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.3",
     "babel-jest": "^22.4.3",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.19.1",


### PR DESCRIPTION
In this diff I added babel plugin which wraps propTypes with
`process.env.NODE_ENV !== 'production'` condition. This allows
webpack in production mode or rollup with replace plugin to eliminate
prop types from final bundle.

These conditions slightly increases library size but as you can see
treeshaked size (in user bundle) become smaller.