### PR TITLE
Remove HeadTag defaults and get rid from default export

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 4440,
-    "minified": 2790,
-    "gzipped": 974
+    "bundled": 4408,
+    "minified": 2767,
+    "gzipped": 960
   },
   "dist/index.esm.js": {
-    "bundled": 3944,
-    "minified": 2379,
-    "gzipped": 877,
+    "bundled": 3897,
+    "minified": 2341,
+    "gzipped": 856,
     "treeshaked": {
       "rollup": {
-        "code": 1076,
+        "code": 317,
         "import_statements": 253
       },
       "webpack": {
-        "code": 2288
+        "code": 1502
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There is nothing special required on the client, just render `<HeadTag />` compo
 
 ```js
 import React from 'react';
-import HeadTag from 'react-head';
+import { HeadTag } from 'react-head';
 
 const App = () => (
    <div className="Home">
@@ -79,9 +79,8 @@ const App = () => (
 The following aliases are also available for use (just convenience components that pre-fill the `tag` prop in `<HeadTag />`):
 
 ```js
-import HeadTag, { Title, Style, Meta, Link } from 'react-head';
+import { HeadTag, Title, Style, Meta, Link } from 'react-head';
 ```
-
 
 ## Contributing
 

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -6,11 +6,7 @@ import { Consumer } from './headTagsContext';
 
 export default class HeadTag extends Component {
   static propTypes = {
-    tag: PropTypes.string,
-  };
-
-  static defaultProps = {
-    tag: 'meta',
+    tag: PropTypes.string.isRequired,
   };
 
   state = {

--- a/src/__tests__/HeadCollector.test.js
+++ b/src/__tests__/HeadCollector.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from 'enzyme';
-import HeadCollector from '../HeadCollector';
-import HeadTag from '../HeadTag';
+import { HeadCollector, HeadTag } from '../';
 
 describe('HeadCollector', () => {
   it('adds HeadTags to given array from component tree', () => {

--- a/src/__tests__/HeadTags.node.test.js
+++ b/src/__tests__/HeadTags.node.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import HeadTag, { HeadCollector, Title, Style, Meta, Link } from '../';
+import { HeadCollector, HeadTag, Title, Style, Meta, Link } from '../';
 
 describe('HeadTag during server rendering', () => {
   const arr = [];

--- a/src/__tests__/HeadTags.web.test.js
+++ b/src/__tests__/HeadTags.web.test.js
@@ -14,7 +14,7 @@ document.head.querySelector = qsMock;
 
 describe('HeadTag during client rendering', () => {
   // eslint-disable-next-line global-require
-  const { default: HeadTag, Title, Style, Meta, Link } = require('../');
+  const { HeadTag, Title, Style, Meta, Link } = require('../');
   const globalCss = `p {
     color: #121212;
   }`;

--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,4 @@ export const Link = props => <HeadTag tag="link" {...props} />;
 
 export { default as HeadCollector } from './HeadCollector';
 
-export default HeadTag;
+export { HeadTag };


### PR DESCRIPTION
Since we had `<Meta />` alias I think we don't need `<HeadTag />` default tag
as `meta`. It's better to keep it required. This allows us to get rid
from `defaultProps` static property and slightly improve the size of
bundle.

Default and named exports in one module often lead to broken esm/cjs interop.
Using only named exports solves the problem.

```
-import HeadTag from 'react-head';
+import { HeadTag } from 'react-head';

- <HeadTag charset='utf-8' />
+ <HeadTag tag='metameta' charset='utf-8' />
```