### PR TITLE
Prefer react named exports

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 4408,
-    "minified": 2767,
-    "gzipped": 960
+    "bundled": 4244,
+    "minified": 2610,
+    "gzipped": 940
   },
   "dist/index.esm.js": {
-    "bundled": 3897,
-    "minified": 2341,
-    "gzipped": 856,
+    "bundled": 3858,
+    "minified": 2296,
+    "gzipped": 846,
     "treeshaked": {
       "rollup": {
-        "code": 317,
-        "import_statements": 253
+        "code": 377,
+        "import_statements": 303
       },
       "webpack": {
-        "code": 1502
+        "code": 1486
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ On the server, the tags are collected in the `headTags[]` array, and then on the
 Wrap your app with `<HeadCollector />` on the server with a given `headTags[]` array to pass down as part of your server-rendered payload.
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import { renderToString } from 'react-dom/server';
 import { HeadCollector } from 'react-head';
 import App from './App';
@@ -61,7 +61,7 @@ res.send(`
 There is nothing special required on the client, just render `<HeadTag />` components whenever you want to inject a tag in the `<head />`.
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import { HeadTag } from 'react-head';
 
 const App = () => (

--- a/src/HeadCollector.js
+++ b/src/HeadCollector.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from './headTagsContext';
 
-export default class HeadCollector extends Component {
+export default class HeadCollector extends React.Component {
   static propTypes = {
     headTags: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
     children: PropTypes.node.isRequired,

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import buildSelector from './buildSelector';
 import { Consumer } from './headTagsContext';
 
-export default class HeadTag extends Component {
+export default class HeadTag extends React.Component {
   static propTypes = {
     tag: PropTypes.string.isRequired,
   };

--- a/src/__tests__/HeadCollector.test.js
+++ b/src/__tests__/HeadCollector.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from 'enzyme';
 import { HeadCollector, HeadTag } from '../';
 

--- a/src/__tests__/HeadTags.node.test.js
+++ b/src/__tests__/HeadTags.node.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { HeadCollector, HeadTag, Title, Style, Meta, Link } from '../';
 

--- a/src/__tests__/HeadTags.web.test.js
+++ b/src/__tests__/HeadTags.web.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 

--- a/src/headTagsContext.js
+++ b/src/headTagsContext.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export const { Consumer, Provider } = React.createContext({
   // on client we don't require HeadCollector

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import HeadTag from './HeadTag';
 
 export const Title = props => <HeadTag tag="title" {...props} />;


### PR DESCRIPTION
In this diff I change default and mixed react imports to named only.
From discussion with Dan Abramov I have a readmap for esm in react.
In react v17 there will be esm entry point with both named and default
export but docs and all components will be recommended to migrate
to named exports. I moving this initiative forward in a lot of modules.

Size also became slightly smaller because of simpler cjs interop.