### PR TITLE
Provide umd bundle and prefer builtins in helpers

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,25 @@
 {
+  "dist/index.umd.js": {
+    "bundled": 5916,
+    "minified": 2673,
+    "gzipped": 1119
+  },
   "dist/index.cjs.js": {
-    "bundled": 4244,
-    "minified": 2610,
-    "gzipped": 940
+    "bundled": 4328,
+    "minified": 2646,
+    "gzipped": 945
   },
   "dist/index.esm.js": {
-    "bundled": 3858,
-    "minified": 2296,
-    "gzipped": 846,
+    "bundled": 3941,
+    "minified": 2330,
+    "gzipped": 856,
     "treeshaked": {
       "rollup": {
-        "code": 377,
-        "import_statements": 303
+        "code": 392,
+        "import_statements": 342
       },
       "webpack": {
-        "code": 1486
+        "code": 1514
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8159,6 +8159,12 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -12375,6 +12381,25 @@
             "estree-walker": "0.5.2",
             "micromatch": "2.3.11"
           }
+        }
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
+      "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "2.0.0",
+        "is-module": "1.0.0",
+        "resolve": "1.7.1"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
+          "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-test-renderer": "^16.3.2",
     "rollup": "^0.61.2",
     "rollup-plugin-babel": "^4.0.0-beta.7",
+    "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-size-snapshot": "^0.5.1"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
@@ -9,10 +10,33 @@ const external = id => !id.startsWith('/') && !id.startsWith('.');
 
 const getBabelOptions = ({ useESModules }) => ({
   runtimeHelpers: true,
-  plugins: [['@babel/transform-runtime', { polyfill: false, useESModules }]],
+  plugins: [['@babel/transform-runtime', { useBuiltIns: true, useESModules }]],
 });
 
+const globals = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  'prop-types': 'PropTypes',
+};
+
 export default [
+  {
+    input,
+    output: {
+      file: 'dist/index.umd.js',
+      format: 'umd',
+      exports: 'named',
+      name: 'ReactHead',
+      globals,
+    },
+    external: Object.keys(globals),
+    plugins: [
+      nodeResolve(),
+      babel(getBabelOptions({ useESModules: true })),
+      sizeSnapshot(),
+    ],
+  },
+
   {
     input,
     output: { file: pkg.main, format: 'cjs', exports: 'named' },


### PR DESCRIPTION
After discussion in https://github.com/tizmagik/react-head/pull/26
I decided to removed polyfills from babel since they all covers only
es5. This trimmed final bundle size significantly from 5kb gzipped to
1kb.

To track this I provided umd bundle in size snapshot.