### PR TITLE
Fix: missing HeadProvider in cjs&esm dist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import HeadTag from './HeadTag';
+import HeadProvider from './HeadProvider';
 
 export const Title = props => <HeadTag tag="title" {...props} />;
 
@@ -9,6 +10,6 @@ export const Meta = props => <HeadTag tag="meta" {...props} />;
 
 export const Link = props => <HeadTag tag="link" {...props} />;
 
-export { default as HeadProvider } from './HeadProvider';
+export default HeadProvider;
 
-export { HeadTag };
+export { HeadTag, HeadProvider };


### PR DESCRIPTION
When using this pack, got warnings and errors
Then found the dist/index.cjs.js has no `HeadProvider` export

Then just fix this.

And tip: before release, please check the dist (maybe include dist files into repo, and review it)