### PR TITLE
Make headTags in <HeadProvider /> optional for client

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,6 +3,7 @@ module.exports = {
   plugins: [
     ['@babel/proposal-class-properties', { loose: true }],
     ['transform-react-remove-prop-types', { mode: 'unsafe-wrap' }],
+    'dev-expression',
   ],
   env: {
     test: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     'react/no-did-mount-set-state': 0,
     'react/sort-comp': 0,
     'react/no-unused-state': 0,
+    'react/require-default-props': 0,
   },
 };

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,30 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7934,
-    "minified": 3489,
-    "gzipped": 1450
+    "bundled": 8138,
+    "minified": 3612,
+    "gzipped": 1494
+  },
+  "dist/index.min.js": {
+    "bundled": 7899,
+    "minified": 3449,
+    "gzipped": 1423
   },
   "dist/index.cjs.js": {
-    "bundled": 6502,
-    "minified": 3669,
-    "gzipped": 1295
+    "bundled": 6762,
+    "minified": 3888,
+    "gzipped": 1380
   },
   "dist/index.esm.js": {
-    "bundled": 6114,
-    "minified": 3356,
-    "gzipped": 1206,
+    "bundled": 6354,
+    "minified": 3560,
+    "gzipped": 1293,
     "treeshaked": {
       "rollup": {
-        "code": 511,
-        "import_statements": 373
+        "code": 541,
+        "import_statements": 403
       },
       "webpack": {
-        "code": 1705
+        "code": 1772
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4787,6 +4787,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-dev-expression": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz",
+      "integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=",
+      "dev": true
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
@@ -10828,7 +10834,7 @@
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
         "vlq": "^0.2.2"
@@ -12647,7 +12653,7 @@
     "rollup-plugin-replace": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
-      "integrity": "sha1-GQdAicjtVxhLjMZOlnoD0JURknc=",
+      "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
       "dev": true,
       "requires": {
         "magic-string": "^0.22.4",
@@ -12737,10 +12743,93 @@
         }
       }
     },
+    "rollup-plugin-uglify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-4.0.0.tgz",
+      "integrity": "sha512-f6W31EQLzxSEYfN3x6/lyljHqXSoCjXKcTsnwz3evQvHgU1+qTzU2SE0SIG7tbAvaCewp2UaZ5x3k6nYsxOP9A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0-beta.47",
+        "uglify-js": "^3.3.25"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+          "integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-rc.1"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+          "integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "uglify-js": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+          "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
+          "dev": true,
+          "requires": {
+            "commander": "~2.16.0",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
+    },
     "rollup-pluginutils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.2.0.tgz",
-      "integrity": "sha512-aqjTUCfZJK3O+TjH++PdQc8Lg6V6t/1Fhu8/6f3qPQzBt0xZruDgqblvb3RQOfKybTgfxKpyy2pQmQ4X2OmY4w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz",
+      "integrity": "sha512-JZS8aJMHEHhqmY2QVPMXwKP6lsD1ShkrcGYjhAIvqKKdXQyPHw/9NF0tl3On/xOJ4ACkxfeG7AF+chfCN1NpBg==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.5.2",
@@ -14255,6 +14344,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-0.0.3.tgz",
+      "integrity": "sha512-SA2YwvDrCITM9fTvHTHRpq9W6L2fBsClbqm3maT5PZux4Z73SPPDYwJMtnoWh6WMgmCkJij/LaOlWiqJqFMK8g=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14724,7 +14818,7 @@
     "vlq": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
     "babel-jest": "^23.4.2",
+    "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.14",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
@@ -76,10 +77,13 @@
     "rollup": "^0.61.2",
     "rollup-plugin-babel": "^4.0.0-beta.8",
     "rollup-plugin-node-resolve": "^3.3.0",
-    "rollup-plugin-size-snapshot": "^0.5.1"
+    "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-size-snapshot": "^0.5.1",
+    "rollup-plugin-uglify": "^4.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-rc.1"
+    "@babel/runtime": "7.0.0-rc.1",
+    "tiny-invariant": "0.0.3"
   },
   "peerDependencies": {
     "react": ">=16.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,13 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
+import replace from 'rollup-plugin-replace';
+import { uglify } from 'rollup-plugin-uglify';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
 
 const input = './src/index.js';
+
+const name = 'ReactHead';
 
 // treat as external everything from node_modules
 const external = id => !id.startsWith('/') && !id.startsWith('.');
@@ -22,18 +26,26 @@ const globals = {
 export default [
   {
     input,
-    output: {
-      file: 'dist/index.umd.js',
-      format: 'umd',
-      exports: 'named',
-      name: 'ReactHead',
-      globals,
-    },
+    output: { file: 'dist/index.umd.js', format: 'umd', name, globals },
     external: Object.keys(globals),
     plugins: [
       nodeResolve(),
       babel(getBabelOptions({ useESModules: true })),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
       sizeSnapshot(),
+    ],
+  },
+
+  {
+    input,
+    output: { file: 'dist/index.min.js', format: 'umd', name, globals },
+    external: Object.keys(globals),
+    plugins: [
+      nodeResolve(),
+      babel(getBabelOptions({ useESModules: true })),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+      sizeSnapshot(),
+      uglify(),
     ],
   },
 

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import invariant from 'tiny-invariant';
 import { Provider } from './headTagsContext';
 
 const cascadingTags = ['title', 'meta'];
 
 export default class HeadProvider extends React.Component {
   static propTypes = {
-    headTags: PropTypes.array.isRequired,
+    headTags: PropTypes.array,
     children: PropTypes.node.isRequired,
   };
 
@@ -47,7 +48,7 @@ export default class HeadProvider extends React.Component {
     },
 
     addServerTag: tagNode => {
-      const { headTags } = this.props;
+      const headTags = this.props.headTags || [];
       // tweak only cascading tags
       if (cascadingTags.indexOf(tagNode.type) !== -1) {
         const index = headTags.findIndex(
@@ -63,6 +64,10 @@ export default class HeadProvider extends React.Component {
   };
 
   render() {
+    invariant(
+      typeof window !== 'undefined' || this.props.headTags,
+      'headTags should be passed to <HeadProvider /> in node'
+    );
     return <Provider value={this.state}>{this.props.children}</Provider>;
   }
 }

--- a/src/__tests__/HeadTags.node.test.js
+++ b/src/__tests__/HeadTags.node.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { HeadProvider, Title, Style, Meta, Link } from '../';
@@ -54,5 +58,15 @@ describe('head tag during server', () => {
       </HeadProvider>
     );
     expect(arr).toMatchSnapshot();
+  });
+
+  it('fails if headTags is not passed to <HeadProvider />', () => {
+    expect(() => {
+      renderToStaticMarkup(
+        <HeadProvider>
+          <Style>{`body {}`}</Style>
+        </HeadProvider>
+      );
+    }).toThrowError(/headTags should be passed/);
   });
 });

--- a/src/__tests__/HeadTags.web.test.js
+++ b/src/__tests__/HeadTags.web.test.js
@@ -46,7 +46,7 @@ describe('head tag during client', () => {
 
   it('renders only the last title', () => {
     const renderer = TestRenderer.create(
-      <HeadProvider headTags={[]}>
+      <HeadProvider>
         <div>
           <Title>Title 1</Title>
         </div>
@@ -63,7 +63,7 @@ describe('head tag during client', () => {
 
   it('mounts and unmounts title', () => {
     const renderer = TestRenderer.create(
-      <HeadProvider headTags={[]}>
+      <HeadProvider>
         <Title>Static</Title>
         <plug.Toggle initial={false}>
           {title => (
@@ -86,7 +86,7 @@ describe('head tag during client', () => {
 
   it('switches between titles', () => {
     const renderer = TestRenderer.create(
-      <HeadProvider headTags={[]}>
+      <HeadProvider>
         <Title>Static</Title>
         <plug.Value initial={null}>
           {title => (
@@ -114,7 +114,7 @@ describe('head tag during client', () => {
 
   it('renders only the last meta with the same name', () => {
     const renderer = TestRenderer.create(
-      <HeadProvider headTags={[]}>
+      <HeadProvider>
         <Meta>Static 1</Meta>
         <Meta name="name1">Static 2</Meta>
         <plug.Toggle initial={false}>


### PR DESCRIPTION
Ref https://github.com/tizmagik/react-head/issues/41

In this diff I made headTags optional and call invariant with ssr
check.

For invariant I used `tiny-invariant` package which is quite small and
simplified version of `fbjs/lib/invariant`.

`babel-plugin-dev-expression` wraps invariant with two cases
- throw error with message in development
- throw empty error in production `invariant failed` message

This allows to strip development only messages and save bytes in user
bundle.