### PR TITLE
Remove prop-types

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -2,7 +2,6 @@ module.exports = {
   presets: [['@babel/env', { modules: false, loose: true }], '@babel/react'],
   plugins: [
     ['@babel/proposal-class-properties', { loose: true }],
-    ['transform-react-remove-prop-types', { mode: 'unsafe-wrap' }],
     // used for stripping out the `invariant` messages in production builds
     'dev-expression',
   ],

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7929,
-    "minified": 3508,
-    "gzipped": 1448
+    "bundled": 7615,
+    "minified": 3339,
+    "gzipped": 1383
   },
   "dist/index.min.js": {
-    "bundled": 7634,
-    "minified": 3305,
-    "gzipped": 1360
+    "bundled": 7485,
+    "minified": 3226,
+    "gzipped": 1333
   },
   "dist/index.cjs.js": {
-    "bundled": 6568,
-    "minified": 3814,
-    "gzipped": 1318
+    "bundled": 6278,
+    "minified": 3563,
+    "gzipped": 1266
   },
   "dist/index.esm.js": {
-    "bundled": 6160,
-    "minified": 3486,
-    "gzipped": 1227,
+    "bundled": 5890,
+    "minified": 3250,
+    "gzipped": 1172,
     "treeshaked": {
       "rollup": {
-        "code": 439,
-        "import_statements": 403
+        "code": 420,
+        "import_statements": 384
       },
       "webpack": {
-        "code": 1670
+        "code": 1616
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4825,12 +4825,6 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
-    "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.14.tgz",
-      "integrity": "sha512-fMlqvLZPX9v7k0Sl4SVzHofQOKTDXvQbpKx+glCm5Ar5L5KQZ8VxjCsYslQwP+KrYXCG6BY7hOp+O1tUVATTDA==",
-      "dev": true
-    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "babel-eslint": "^8.2.6",
     "babel-jest": "^23.4.2",
     "babel-plugin-dev-expression": "^0.2.1",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.14",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",
@@ -68,7 +67,6 @@
     "lint-staged": "^7.1.0",
     "npm-run-all": "^4.1.3",
     "prettier": "^1.12.1",
-    "prop-types": "^15.6.2",
     "raf": "^3.4.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
@@ -86,7 +84,6 @@
     "tiny-invariant": "^1.0.0"
   },
   "peerDependencies": {
-    "prop-types": ">=15",
     "react": ">=16.3",
     "react-dom": ">=16.3"
   },

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -1,16 +1,10 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import invariant from 'tiny-invariant';
 import { Provider } from './context';
 
 const cascadingTags = ['title', 'meta'];
 
 export default class HeadProvider extends React.Component {
-  static propTypes = {
-    headTags: PropTypes.array,
-    children: PropTypes.node.isRequired,
-  };
-
   indices = new Map();
 
   state = {
@@ -73,8 +67,8 @@ export default class HeadProvider extends React.Component {
 
   render() {
     invariant(
-      typeof window !== 'undefined' || this.props.headTags,
-      'headTags should be passed to <HeadProvider /> in node'
+      typeof window !== 'undefined' || Array.isArray(this.props.headTags),
+      'headTags array should be passed to <HeadProvider /> in node'
     );
     return <Provider value={this.state}>{this.props.children}</Provider>;
   }

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 import invariant from 'tiny-invariant';
 import { Consumer } from './context';
 
 export default class HeadTag extends React.Component {
-  static propTypes = {
-    tag: PropTypes.string.isRequired,
-  };
-
   state = {
     canUseDOM: false,
   };

--- a/tests/ssr.test.js
+++ b/tests/ssr.test.js
@@ -64,7 +64,17 @@ describe('head tag during server', () => {
           <Style>{`body {}`}</Style>
         </HeadProvider>
       );
-    }).toThrowError(/headTags should be passed/);
+    }).toThrowError(/headTags array should be passed/);
+  });
+
+  it('fails if headTags is not an array', () => {
+    expect(() => {
+      renderToStaticMarkup(
+        <HeadProvider headTags={{}}>
+          <Style>{`body {}`}</Style>
+        </HeadProvider>
+      );
+    }).toThrowError(/headTags array should be passed/);
   });
 
   it('throw error if head tag is rendered without HeadProvider', () => {


### PR DESCRIPTION
`HeadTag` is implementation detail and aliases always pass tag prop,
prop-types are not required in this component.

`HeadProvider` prop types are not significant. `headTags` is asserted
in render. Covering `children` doesn't have any DX matter.