### PR TITLE
Allow Googlebot and older browsers to render HeadProvider

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7848,
-    "minified": 3450,
-    "gzipped": 1418
+    "bundled": 7826,
+    "minified": 3433,
+    "gzipped": 1408
   },
   "dist/index.min.js": {
-    "bundled": 7718,
-    "minified": 3337,
-    "gzipped": 1367
+    "bundled": 7696,
+    "minified": 3320,
+    "gzipped": 1356
   },
   "dist/index.cjs.js": {
-    "bundled": 6500,
-    "minified": 3674,
-    "gzipped": 1298
+    "bundled": 6478,
+    "minified": 3657,
+    "gzipped": 1289
   },
   "dist/index.esm.js": {
-    "bundled": 6112,
-    "minified": 3361,
-    "gzipped": 1204,
+    "bundled": 6090,
+    "minified": 3344,
+    "gzipped": 1195,
     "treeshaked": {
       "rollup": {
         "code": 420,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7804,
-    "minified": 3404,
-    "gzipped": 1401
+    "bundled": 7848,
+    "minified": 3450,
+    "gzipped": 1418
   },
   "dist/index.min.js": {
-    "bundled": 7674,
-    "minified": 3291,
-    "gzipped": 1350
+    "bundled": 7718,
+    "minified": 3337,
+    "gzipped": 1367
   },
   "dist/index.cjs.js": {
-    "bundled": 6456,
-    "minified": 3628,
-    "gzipped": 1281
+    "bundled": 6500,
+    "minified": 3674,
+    "gzipped": 1298
   },
   "dist/index.esm.js": {
-    "bundled": 6068,
-    "minified": 3315,
-    "gzipped": 1187,
+    "bundled": 6112,
+    "minified": 3361,
+    "gzipped": 1204,
     "treeshaked": {
       "rollup": {
         "code": 420,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7826,
+    "bundled": 7905,
     "minified": 3433,
     "gzipped": 1408
   },
   "dist/index.min.js": {
-    "bundled": 7696,
+    "bundled": 7775,
     "minified": 3320,
     "gzipped": 1356
   },
   "dist/index.cjs.js": {
-    "bundled": 6478,
+    "bundled": 6557,
     "minified": 3657,
     "gzipped": 1289
   },
   "dist/index.esm.js": {
-    "bundled": 6090,
+    "bundled": 6169,
     "minified": 3344,
     "gzipped": 1195,
     "treeshaked": {

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -63,6 +63,7 @@ export default class HeadProvider extends React.Component {
 
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
+    // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
     Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
   }
 

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -63,9 +63,7 @@ export default class HeadProvider extends React.Component {
 
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
-    Array.prototype.forEach.call(ssrTags, ssrTag =>
-      ssrTag.parentNode.removeChild(ssrTag)
-    );
+    Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
   }
 
   render() {

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -63,7 +63,7 @@ export default class HeadProvider extends React.Component {
 
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
-    ssrTags.forEach(ssrTag => ssrTag.remove());
+    Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
   }
 
   render() {

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -63,7 +63,9 @@ export default class HeadProvider extends React.Component {
 
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
-    Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
+    Array.prototype.forEach.call(ssrTags, ssrTag =>
+      ssrTag.parentNode.removeChild(ssrTag)
+    );
   }
 
   render() {


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/NodeList) the `NodeList` returned by `querySelectorAll` only supports `forEach` in modern browsers. The most notable browser missing off this list if Chromium ~41, which is the rendering ending that Googlebot is based on. By removing the `NodeList` `forEach` call, also per the MDN article, we can get Google rendering again.