### PR TITLE
Add titleTemplate option to ease Helmet migration

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7905,
-    "minified": 3433,
-    "gzipped": 1408
+    "bundled": 8494,
+    "minified": 3715,
+    "gzipped": 1507
   },
   "dist/index.min.js": {
-    "bundled": 7775,
-    "minified": 3320,
-    "gzipped": 1356
+    "bundled": 8364,
+    "minified": 3602,
+    "gzipped": 1455
   },
   "dist/index.cjs.js": {
-    "bundled": 6557,
-    "minified": 3657,
-    "gzipped": 1289
+    "bundled": 7116,
+    "minified": 3980,
+    "gzipped": 1391
   },
   "dist/index.esm.js": {
-    "bundled": 6169,
-    "minified": 3344,
-    "gzipped": 1195,
+    "bundled": 6728,
+    "minified": 3667,
+    "gzipped": 1300,
     "treeshaked": {
       "rollup": {
-        "code": 420,
+        "code": 2587,
         "import_statements": 384
       },
       "webpack": {
-        "code": 1616
+        "code": 3883
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ const App = () => (
 );
 ```
 
+### Options
+
+```js
+<HeadProvider
+  titleTemplate="%s - Sitename" // Title will be output per template, replacing %s with title text
+  />
+```
+
 ## Contributing
 
 Please follow the [contributing docs](/CONTRIBUTING.md)

--- a/example/src/Contact.js
+++ b/example/src/Contact.js
@@ -5,13 +5,11 @@ import { Link as RouterLink } from '@reach/router';
 import logo from './react.svg';
 import './Contact.css';
 
-const NestedComponent = () => (
-  <Title>Contact | Example react-head App (with cascading title)</Title>
-);
+const NestedComponent = () => <Title>Contact (with cascade)</Title>;
 
 const Contact = () => (
   <div className="Contact">
-    <Title>Contact | Example react-head App</Title>
+    <Title>Contact</Title>
     <Link rel="canonical" content="http://jeremygayed.com/" />
     <Meta name="keywords" content="Contact,Example,React,Header" />
     <div className="Contact-header">

--- a/example/src/Home.js
+++ b/example/src/Home.js
@@ -11,7 +11,7 @@ const NestedComponent = () => (
 
 const Home = () => (
   <div className="Home">
-    <Title>Home | Example react-head App</Title>
+    <Title>Home</Title>
     <Style>{`p {
       color: #121212;
     }`}</Style>

--- a/example/src/client.js
+++ b/example/src/client.js
@@ -4,7 +4,7 @@ import { HeadProvider } from 'react-head';
 import App from './App';
 
 hydrate(
-  <HeadProvider>
+  <HeadProvider titleTemplate="%s | Example react-head App">
     <App />
   </HeadProvider>,
   document.getElementById('root')

--- a/example/src/server.js
+++ b/example/src/server.js
@@ -18,7 +18,10 @@ server
     try {
       markup = renderToString(
         <ServerLocation url={req.url}>
-          <HeadProvider headTags={headTags}>
+          <HeadProvider
+            headTags={headTags}
+            titleTemplate="%s | Example react-head App"
+          >
             <App />
           </HeadProvider>
         </ServerLocation>

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -5,6 +5,10 @@ import { Provider } from './context';
 const cascadingTags = ['title', 'meta'];
 
 export default class HeadProvider extends React.Component {
+  static defaultProps = {
+    titleTemplate: '%s',
+  };
+
   indices = new Map();
 
   state = {
@@ -59,6 +63,8 @@ export default class HeadProvider extends React.Component {
       }
       headTags.push(tagNode);
     },
+
+    titleTemplate: this.props.titleTemplate,
   };
 
   componentDidMount() {

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -4,6 +4,9 @@ import invariant from 'tiny-invariant';
 import { Consumer } from './context';
 
 export default class HeadTag extends React.Component {
+  static defaultProps = {
+    outputTemplate: (h, s) => s,
+  };
   state = {
     canUseDOM: false,
   };
@@ -22,7 +25,7 @@ export default class HeadTag extends React.Component {
   }
 
   render() {
-    const { tag: Tag, ...rest } = this.props;
+    const { tag: Tag, children, outputTemplate, ...rest } = this.props;
 
     return (
       <Consumer>
@@ -35,11 +38,18 @@ export default class HeadTag extends React.Component {
             if (!headTags.shouldRenderTag(Tag, this.index)) {
               return null;
             }
-            const ClientComp = <Tag {...rest} />;
+
+            const ClientComp = (
+              <Tag {...rest}>{outputTemplate(headTags, children)}</Tag>
+            );
             return ReactDOM.createPortal(ClientComp, document.head);
           }
 
-          const ServerComp = <Tag data-rh="" {...rest} />;
+          const ServerComp = (
+            <Tag data-rh="" {...rest}>
+              {outputTemplate(headTags, children)}
+            </Tag>
+          );
           headTags.addServerTag(ServerComp);
           return null;
         }}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import HeadTag from './HeadTag';
 
-export const Title = props => <HeadTag tag="title" {...props} />;
+const renderTitle = (headTags, children) =>
+  headTags.titleTemplate.replace('%s', `${children}`);
+
+export const Title = props => (
+  <HeadTag outputTemplate={renderTitle} tag="title" {...props} />
+);
 
 export const Style = props => <HeadTag tag="style" {...props} />;
 

--- a/tests/__snapshots__/ssr.test.js.snap
+++ b/tests/__snapshots__/ssr.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a title matching the template 1`] = `
+Array [
+  <title
+    data-rh=""
+  >
+    Title 3 - test
+  </title>,
+]
+`;
+
 exports[`renders nothing and adds tags to headTags context array 1`] = `"<div>Yes render</div>"`;
 
 exports[`renders nothing and adds tags to headTags context array 2`] = `

--- a/tests/ssr.test.js
+++ b/tests/ssr.test.js
@@ -23,6 +23,24 @@ test('renders nothing and adds tags to headTags context array', () => {
   expect(arr).toMatchSnapshot();
 });
 
+test('renders a title matching the template', () => {
+  const arr = [];
+  renderToStaticMarkup(
+    <HeadProvider headTags={arr} titleTemplate="%s - test">
+      <div>
+        <Title>Title 1</Title>
+      </div>
+      <div>
+        <Title>Title 2</Title>
+      </div>
+      <div>
+        <Title>Title 3</Title>
+      </div>
+    </HeadProvider>
+  );
+  expect(arr).toMatchSnapshot();
+});
+
 test('renders only the last title', () => {
   const arr = [];
   renderToStaticMarkup(


### PR DESCRIPTION
We were moving away from react-helmet for a few reasons and not having this was a pain point so I've added it.

It's done via the addition of an `outputTemplate` option in the tags, which could be used to provide custom output processing of any sort, then having a default option for `<Title>` which does a simple string replace to render the format provided in `titleTemplate`.

`titleTemplate` is provided on the `<HeadProvider>`, which is a little different to how Helmet used to do it but I think I prefer it.

I've not tested with the suggested dev server because of https://github.com/tizmagik/react-head/issues/64 but am using it in a fairly substantial project and have provided tests.
