### PR TITLE
Add serverOnly prop to skip client side render

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7905,
-    "minified": 3433,
-    "gzipped": 1408
+    "bundled": 8120,
+    "minified": 3550,
+    "gzipped": 1454
   },
   "dist/index.min.js": {
-    "bundled": 7775,
-    "minified": 3320,
-    "gzipped": 1356
+    "bundled": 7990,
+    "minified": 3437,
+    "gzipped": 1402
   },
   "dist/index.cjs.js": {
-    "bundled": 6557,
-    "minified": 3657,
-    "gzipped": 1289
+    "bundled": 6758,
+    "minified": 3789,
+    "gzipped": 1335
   },
   "dist/index.esm.js": {
-    "bundled": 6169,
-    "minified": 3344,
-    "gzipped": 1195,
+    "bundled": 6370,
+    "minified": 3476,
+    "gzipped": 1242,
     "treeshaked": {
       "rollup": {
-        "code": 420,
+        "code": 1695,
         "import_statements": 384
       },
       "webpack": {
-        "code": 1616
+        "code": 2898
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ const App = () => (
 );
 ```
 
+### Options
+
+```js
+<HeadProvider
+  serverOnly // Only render tags on the server, do not replace on client render
+  />
+```
+
+Note that the `serverOnly` option will also remove the `data-rh=""` properties from the rendered tags, as the client does not use them.
+
 ## Contributing
 
 Please follow the [contributing docs](/CONTRIBUTING.md)

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -5,6 +5,10 @@ import { Provider } from './context';
 const cascadingTags = ['title', 'meta'];
 
 export default class HeadProvider extends React.Component {
+  static defaultProps = {
+    serverOnly: false,
+  };
+
   indices = new Map();
 
   state = {
@@ -59,12 +63,16 @@ export default class HeadProvider extends React.Component {
       }
       headTags.push(tagNode);
     },
+
+    serverOnly: this.props.serverOnly,
   };
 
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
-    // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
-    Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
+    if (!this.props.serverOnly) {
+      // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
+      Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
+    }
   }
 
   render() {

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -31,7 +31,7 @@ export default class HeadTag extends React.Component {
 
           this.headTags = headTags;
 
-          if (this.state.canUseDOM) {
+          if (this.state.canUseDOM && !headTags.serverOnly) {
             if (!headTags.shouldRenderTag(Tag, this.index)) {
               return null;
             }
@@ -39,7 +39,9 @@ export default class HeadTag extends React.Component {
             return ReactDOM.createPortal(ClientComp, document.head);
           }
 
-          const ServerComp = <Tag data-rh="" {...rest} />;
+          const ServerComp = (
+            <Tag data-rh={headTags.serverOnly ? null : ''} {...rest} />
+          );
           headTags.addServerTag(ServerComp);
           return null;
         }}

--- a/tests/__snapshots__/dom.test.js.snap
+++ b/tests/__snapshots__/dom.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not alter head tags if serverOnly 1`] = `
+"
+      <title>Test title</title>
+      <style>
+        body {}
+      </style>
+      <link href=\\"index.css\\">
+      <not-react-head-element>
+    </not-react-head-element>"
+`;
+
+exports[`does not alter head tags if serverOnly 2`] = `
+"
+      <title>Test title</title>
+      <style>
+        body {}
+      </style>
+      <link href=\\"index.css\\">
+      <not-react-head-element>
+    </not-react-head-element>"
+`;
+
 exports[`removes head tags added during ssr 1`] = `
 "
       <title data-rh=\\"\\">Test title</title>

--- a/tests/__snapshots__/ssr.test.js.snap
+++ b/tests/__snapshots__/ssr.test.js.snap
@@ -85,3 +85,28 @@ Array [
   </title>,
 ]
 `;
+
+exports[`skips data-rh attributes if serverOnly 1`] = `"<div>Yes render</div>"`;
+
+exports[`skips data-rh attributes if serverOnly 2`] = `
+Array [
+  <title
+    data-rh={null}
+  >
+    Title
+  </title>,
+  <style
+    data-rh={null}
+  >
+    body {}
+  </style>,
+  <link
+    data-rh={null}
+    href="index.css"
+  />,
+  <meta
+    charSet="utf-8"
+    data-rh={null}
+  />,
+]
+`;

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -32,3 +32,34 @@ test('removes head tags added during ssr', () => {
 
   expect(document.head.innerHTML).toMatchSnapshot();
 });
+
+test('does not alter head tags if serverOnly', () => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  document.head.innerHTML = `
+      <title>Test title</title>
+      <style>
+        body {}
+      </style>
+      <link href="index.css" />
+      <not-react-head-element />
+    `;
+
+  expect(document.head.innerHTML).toMatchSnapshot();
+
+  ReactDOM.render(
+    <HeadProvider serverOnly>
+      <div>
+        Yes render
+        <Title>Test title</Title>
+        <Style>{`body {}`}</Style>
+        <Link href="index.css" />
+        <Meta charSet="utf-8" />
+      </div>
+    </HeadProvider>,
+    root
+  );
+
+  expect(document.head.innerHTML).toMatchSnapshot();
+});

--- a/tests/ssr.test.js
+++ b/tests/ssr.test.js
@@ -23,6 +23,23 @@ test('renders nothing and adds tags to headTags context array', () => {
   expect(arr).toMatchSnapshot();
 });
 
+test('skip data-rh attributes if serverOnly', () => {
+  const arr = [];
+  const markup = renderToStaticMarkup(
+    <HeadProvider headTags={arr} serverOnly>
+      <div>
+        Yes render
+        <Title>Title</Title>
+        <Style>{`body {}`}</Style>
+        <Link href="index.css" />
+        <Meta charSet="utf-8" />
+      </div>
+    </HeadProvider>
+  );
+  expect(markup).toMatchSnapshot();
+  expect(arr).toMatchSnapshot();
+});
+
 test('renders only the last title', () => {
   const arr = [];
   renderToStaticMarkup(


### PR DESCRIPTION
We're SSR-only for `<head>` stuff at the moment and need `<meta>` tags and the like to not be cluttered - it is a validation issue for AMP. Even if it weren't I don't like having them when they're not needed.

This adds a `serverOnly` prop which will skip the client render entirely and strip out the `data-rh=""` properties.

I've not tested with the suggested dev server because of https://github.com/tizmagik/react-head/issues/64 but am using it in a fairly substantial project and have provided tests.