### PR TITLE
ssrTags are removed using removeSafe method

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7905,
-    "minified": 3433,
-    "gzipped": 1408
+    "bundled": 7893,
+    "minified": 3460,
+    "gzipped": 1427
   },
   "dist/index.min.js": {
-    "bundled": 7775,
-    "minified": 3320,
-    "gzipped": 1356
+    "bundled": 7763,
+    "minified": 3344,
+    "gzipped": 1372
   },
   "dist/index.cjs.js": {
-    "bundled": 6557,
-    "minified": 3657,
-    "gzipped": 1289
+    "bundled": 1024,
+    "minified": 791,
+    "gzipped": 328
   },
   "dist/index.esm.js": {
     "bundled": 6169,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7893,
-    "minified": 3460,
-    "gzipped": 1427
+    "bundled": 7927,
+    "minified": 3450,
+    "gzipped": 1418
   },
   "dist/index.min.js": {
-    "bundled": 7763,
-    "minified": 3344,
-    "gzipped": 1372
+    "bundled": 7797,
+    "minified": 3337,
+    "gzipped": 1367
   },
   "dist/index.cjs.js": {
-    "bundled": 1024,
-    "minified": 791,
-    "gzipped": 328
+    "bundled": 6579,
+    "minified": 3674,
+    "gzipped": 1298
   },
   "dist/index.esm.js": {
-    "bundled": 6169,
-    "minified": 3344,
-    "gzipped": 1195,
+    "bundled": 6191,
+    "minified": 3361,
+    "gzipped": 1204,
     "treeshaked": {
       "rollup": {
         "code": 420,

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -4,6 +4,14 @@ import { Provider } from './context';
 
 const cascadingTags = ['title', 'meta'];
 
+const safeRemove = tag => {
+  if (tag.remove) {
+    tag.remove();
+  } else if (tag.parentNode !== null) {
+    tag.parentNode.removeChild(tag);
+  }
+};
+
 export default class HeadProvider extends React.Component {
   indices = new Map();
 
@@ -64,7 +72,7 @@ export default class HeadProvider extends React.Component {
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
     // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
-    Array.prototype.forEach.call(ssrTags, ssrTag => ssrTag.remove());
+    Array.prototype.forEach.call(ssrTags, ssrTag => safeRemove(ssrTag));
   }
 
   render() {

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -4,14 +4,6 @@ import { Provider } from './context';
 
 const cascadingTags = ['title', 'meta'];
 
-const safeRemove = tag => {
-  if (tag.remove) {
-    tag.remove();
-  } else if (tag.parentNode !== null) {
-    tag.parentNode.removeChild(tag);
-  }
-};
-
 export default class HeadProvider extends React.Component {
   indices = new Map();
 
@@ -72,7 +64,9 @@ export default class HeadProvider extends React.Component {
   componentDidMount() {
     const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
     // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
-    Array.prototype.forEach.call(ssrTags, ssrTag => safeRemove(ssrTag));
+    Array.prototype.forEach.call(ssrTags, ssrTag =>
+      ssrTag.parentNode.removeChild(ssrTag)
+    );
   }
 
   render() {


### PR DESCRIPTION
This prevents an exception in IE because ChildNode.remove() is not supported there.