### PR TITLE
Flow doesn't like passing no type parameter to React.Element, so pass `any`

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 declare export var HeadProvider: React.ComponentType<{
-  headTags: Array<React.Element<any>>,
+  headTags?: Array<React.Element<any>>,
   children: React.Node,
 }>;
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 declare export var HeadProvider: React.ComponentType<{
-  headTags: Array<React.Element<>>,
+  headTags: Array<React.Element<any>>,
   children: React.Node,
 }>;
 


### PR DESCRIPTION
I know who uses flow anymore right?