### PR TITLE
Add Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SSR-ready Document Head management for React 16+",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "types": "src/index.d.ts",
   "files": [
     "src",
     "dist"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+/**
+ * Context based provider for managing head tags
+ */
+export const HeadProvider: React.ComponentType<{
+  headTags?: React.ReactElement<unknown>[];
+}>;
+
+/**
+ * <title> tag component
+ */
+export const Title: React.ComponentType<React.HTMLAttributes<HTMLTitleElement>>;
+
+/**
+ * <style> tag component
+ */
+export const Style: React.ComponentType<React.HTMLAttributes<HTMLStyleElement>>;
+
+/**
+ * <meta> tag component
+ */
+export const Meta: React.ComponentType<React.HTMLAttributes<HTMLMetaElement>>;
+
+/**
+ * <link> tag component
+ */
+export const Link: React.ComponentType<React.HTMLAttributes<HTMLLinkElement>>;


### PR DESCRIPTION
Fixes #75

As src folder is still published due to dist flow types referral, I just added reference to `src/index.d.ts` and didn't touch any build scripts for now.

