### PR TITLE
Added missing type properties (name and content) to Typescript typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,22 +7,24 @@ export const HeadProvider: React.ComponentType<{
   headTags?: React.ReactElement<unknown>[];
 }>;
 
+type HeadTagProps = {name?: string, content?: string};
 /**
  * <title> tag component
  */
-export const Title: React.ComponentType<React.HTMLAttributes<HTMLTitleElement>>;
+export const Title: React.ComponentType<React.HTMLAttributes<HTMLTitleElement> & HeadTagProps>;
 
 /**
  * <style> tag component
  */
-export const Style: React.ComponentType<React.HTMLAttributes<HTMLStyleElement>>;
+export const Style: React.ComponentType<React.HTMLAttributes<HTMLStyleElement> & HeadTagProps>;
 
 /**
  * <meta> tag component
  */
-export const Meta: React.ComponentType<React.HTMLAttributes<HTMLMetaElement>>;
+export const Meta: React.ComponentType<React.HTMLAttributes<HTMLMetaElement> & HeadTagProps>;
 
 /**
  * <link> tag component
  */
-export const Link: React.ComponentType<React.HTMLAttributes<HTMLLinkElement>>;
+export const Link: React.ComponentType<React.HTMLAttributes<HTMLLinkElement> & HeadTagProps>;
+


### PR DESCRIPTION
Added missing type properties (name and content) to Typescript typings for the Title, Style, Meta, and Link components (since they all actually inherit from HeadTag)