### PR TITLE
fix(typings): fix type definitions for exported HTML components

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,14 +15,20 @@ export const Title: React.ComponentType<React.HTMLAttributes<HTMLTitleElement>>;
 /**
  * <style> tag component
  */
-export const Style: React.ComponentType<React.HTMLAttributes<HTMLStyleElement>>;
+export const Style: React.ComponentType<
+  React.StyleHTMLAttributes<HTMLStyleElement>
+>;
 
 /**
  * <meta> tag component
  */
-export const Meta: React.ComponentType<React.HTMLAttributes<HTMLMetaElement>>;
+export const Meta: React.ComponentType<
+  React.MetaHTMLAttributes<HTMLMetaElement>
+>;
 
 /**
  * <link> tag component
  */
-export const Link: React.ComponentType<React.HTMLAttributes<HTMLLinkElement>>;
+export const Link: React.ComponentType<
+  React.LinkHTMLAttributes<HTMLLinkElement>
+>;


### PR DESCRIPTION
```ts
import { Link } from 'react-head';

...

<Link
  rel="stylesheet"
  href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"
/>
```

I was using the `Link` component and was receiving this error:
```
Property 'rel' does not exist on type 'IntrinsicAttributes & HTMLAttributes<HTMLLinkElement> & { children?: ReactNode; }'
```

I took a look on the typings and I realized that they were using the generic `HTMLAttributes` interface rather than the more specific for each tag that includes the particularities of each one, so I went ahead and changed it, and the errors were gone.

cc @TrySound @msokk as per #78.  