### PR TITLE
fix: add whitelist prop to HeadProvider

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7927,
-    "minified": 3450,
-    "gzipped": 1418
+    "bundled": 8390,
+    "minified": 3665,
+    "gzipped": 1514
   },
   "dist/index.min.js": {
-    "bundled": 7797,
-    "minified": 3337,
-    "gzipped": 1367
+    "bundled": 8260,
+    "minified": 3552,
+    "gzipped": 1461
   },
   "dist/index.cjs.js": {
-    "bundled": 6579,
-    "minified": 3674,
-    "gzipped": 1298
+    "bundled": 7026,
+    "minified": 3889,
+    "gzipped": 1393
   },
   "dist/index.esm.js": {
-    "bundled": 6191,
-    "minified": 3361,
-    "gzipped": 1204,
+    "bundled": 6638,
+    "minified": 3576,
+    "gzipped": 1297,
     "treeshaked": {
       "rollup": {
         "code": 420,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ const App = () => (
 );
 ```
 
+## Disable data-rh attribute
+
+`<HeadProvider/>` accepts an optional prop `whitelist` which accepts a comma separated CSS selector string just like `document.querySelector`. This allows `react-head` to know which tags it controlls without the need for the `data-rh` attribute, which might lead to problems with some HTML parsers of SEO tools for example.
+
+### Example
+
+```jsx
+// on the server
+<HeadProvider headTags={headTags} whitelist="title,[name="description"],[property^="og:"]">
+  <App />
+</HeadProvider>
+
+// in the client
+<HeadProvider whitelist="title,[name="description"],[property^="og:"]">
+  <div id="app">
+    <Title>Title of page</Title>
+    // ...
+  </div>
+</HeadProvider>
+```
+
 ## Contributing
 
 Please follow the [contributing docs](/CONTRIBUTING.md)

--- a/example/src/client.js
+++ b/example/src/client.js
@@ -4,7 +4,7 @@ import { HeadProvider } from 'react-head';
 import App from './App';
 
 hydrate(
-  <HeadProvider>
+  <HeadProvider whitelist="title">
     <App />
   </HeadProvider>,
   document.getElementById('root')

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -59,10 +59,15 @@ export default class HeadProvider extends React.Component {
       }
       headTags.push(tagNode);
     },
+
+    whitelist: this.props.whitelist || ``,
   };
 
   componentDidMount() {
-    const ssrTags = document.head.querySelectorAll(`[data-rh=""]`);
+    const whitelist = `${this.state.whitelist}`
+      ? `,${this.state.whitelist}`
+      : ``;
+    const ssrTags = document.head.querySelectorAll(`[data-rh=""]${whitelist}`);
     // `forEach` on `NodeList` is not supported in Googlebot, so use a workaround
     Array.prototype.forEach.call(ssrTags, ssrTag =>
       ssrTag.parentNode.removeChild(ssrTag)

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -39,7 +39,11 @@ export default class HeadTag extends React.Component {
             return ReactDOM.createPortal(ClientComp, document.head);
           }
 
-          const ServerComp = <Tag data-rh="" {...rest} />;
+          // disable `data-rh` if <HeadProvider whitelist /> matches Tag
+          const dataAttribute = `${headTags.whitelist}`.split(`,`).includes(Tag)
+            ? {}
+            : { 'data-rh': `` };
+          const ServerComp = <Tag {...dataAttribute} {...rest} />;
           headTags.addServerTag(ServerComp);
           return null;
         }}


### PR DESCRIPTION
`<HeadProvider/>` accepts additional prop `whitelist` which takes a CSS selector string (used in `document.querySelector`) to disable `data-rh` for identification on whitelisted tags

As mentioned here https://github.com/tizmagik/react-head/issues/40
based on https://github.com/nfl/react-helmet/issues/79

As it doesn't seem too heavy, I think it's a good addition which could make many former `react-helmet` users pretty happy

I plan another PR soon'ish🤞 to add support for html & body attributes as mentioned here https://github.com/tizmagik/react-head/issues/40
I'm working on a new website for our [org](https://github.com/Gaiama/gaiama.org) right now and am evaluating plugins one by one, not just copying everything from the main website.

If all this gets merged I would publish a `gatsby-plugin-react-head`, I've already prepared, which could make `react-head` more interesting to many gatsbys 💜 