### PR TITLE
Fixes prop mutation

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 7927,
-    "minified": 3450,
-    "gzipped": 1418
+    "bundled": 7963,
+    "minified": 3461,
+    "gzipped": 1426
   },
   "dist/index.min.js": {
-    "bundled": 7797,
-    "minified": 3337,
-    "gzipped": 1367
+    "bundled": 7833,
+    "minified": 3348,
+    "gzipped": 1375
   },
   "dist/index.cjs.js": {
-    "bundled": 6579,
-    "minified": 3674,
-    "gzipped": 1298
+    "bundled": 6613,
+    "minified": 3685,
+    "gzipped": 1310
   },
   "dist/index.esm.js": {
-    "bundled": 6191,
-    "minified": 3361,
-    "gzipped": 1204,
+    "bundled": 6225,
+    "minified": 3372,
+    "gzipped": 1215,
     "treeshaked": {
       "rollup": {
         "code": 420,

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -45,7 +45,7 @@ export default class HeadProvider extends React.Component {
     },
 
     addServerTag: tagNode => {
-      const headTags = this.props.headTags || [];
+      const headTags = (this.props.headTags || []).slice(0); // clone array
       // tweak only cascading tags
       if (cascadingTags.indexOf(tagNode.type) !== -1) {
         const index = headTags.findIndex(prev => {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -32,3 +32,18 @@ test('removes head tags added during ssr', () => {
 
   expect(document.head.innerHTML).toMatchSnapshot();
 });
+
+test('leaves headTags prop unmodified after render', () => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+
+  const tags = [];
+  ReactDOM.render(
+    <HeadProvider headTags={tags}>
+      <Title>Test title</Title>
+    </HeadProvider>,
+    root
+  );
+
+  expect(tags).toEqual([]);
+});


### PR DESCRIPTION
Hi there! We use react-head at Artsy (thank you for the great library!) and recently saw an issue with our site emitting some meta tags twice. The problem, fixed in [this PR](https://github.com/artsy/reaction/pull/2327), was that we had an array of tags, passed in as the `headTags` prop, but it was being modified on when rendered (we render twice to prime a [Relay cache](https://github.com/artsy/reaction/blob/048227b3df85d74f34f7db71859fd427a133d102/src/Artsy/Router/buildServerApp.tsx#L105-L113) in SSR-rendered pages).

It seems like `read-head` is mutating (via `.push()`) the `headTags` prop. I've added a test and changed it to clone the prop instead of modifying it directly. Thanks again!