### PR TITLE
Drop tiny-invariant

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/index.umd.js": {
-    "bundled": 8212,
-    "minified": 3515,
-    "gzipped": 1451
+    "bundled": 8049,
+    "minified": 3466,
+    "gzipped": 1418
   },
   "dist/index.min.js": {
-    "bundled": 8080,
-    "minified": 3399,
-    "gzipped": 1397
+    "bundled": 8049,
+    "minified": 3466,
+    "gzipped": 1418
   },
   "dist/index.cjs.js": {
-    "bundled": 6855,
-    "minified": 3699,
-    "gzipped": 1317
+    "bundled": 6704,
+    "minified": 3556,
+    "gzipped": 1274
   },
   "dist/index.esm.js": {
-    "bundled": 6467,
-    "minified": 3386,
-    "gzipped": 1221,
+    "bundled": 6336,
+    "minified": 3258,
+    "gzipped": 1182,
     "treeshaked": {
       "rollup": {
-        "code": 328,
-        "import_statements": 292
+        "code": 305,
+        "import_statements": 269
       },
       "webpack": {
-        "code": 1616
+        "code": 1549
       }
     }
   }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,4 @@
 module.exports = {
   presets: [['@babel/env', { loose: true }], '@babel/react'],
-  plugins: [
-    ['@babel/proposal-class-properties', { loose: true }],
-    // used for stripping out the `invariant` messages in production builds
-    'dev-expression',
-  ],
+  plugins: [['@babel/proposal-class-properties', { loose: true }]],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,12 +1799,6 @@
         "slash": "^2.0.0"
       }
     },
-    "babel-plugin-dev-expression": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.2.tgz",
-      "integrity": "sha512-y32lfBif+c2FIh5dwGfcc/IfX5aw/Bru7Du7W2n17sJE/GJGAsmIk5DPW/8JOoeKpXW5evJfJOvRq5xkiS6vng==",
-      "dev": true
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -8999,11 +8993,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
-    "babel-plugin-dev-expression": "^0.2.2",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",
@@ -80,8 +79,7 @@
     "rollup-plugin-uglify": "^6.0.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.3",
-    "tiny-invariant": "^1.0.6"
+    "@babel/runtime": "^7.6.3"
   },
   "peerDependencies": {
     "react": ">=16.3",

--- a/src/HeadProvider.js
+++ b/src/HeadProvider.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import invariant from 'tiny-invariant';
 import { Provider } from './context';
 
 const cascadingTags = ['title', 'meta'];
@@ -72,10 +71,12 @@ export default class HeadProvider extends React.Component {
   render() {
     const { headTags, children } = this.props;
 
-    invariant(
-      typeof window !== 'undefined' || Array.isArray(headTags),
-      'headTags array should be passed to <HeadProvider /> in node'
-    );
+    if (typeof window === 'undefined' && Array.isArray(headTags) === false) {
+      throw Error(
+        'headTags array should be passed to <HeadProvider /> in node'
+      );
+    }
+
     return <Provider value={this.state}>{children}</Provider>;
   }
 }

--- a/src/HeadTag.js
+++ b/src/HeadTag.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import invariant from 'tiny-invariant';
 import { Consumer } from './context';
 
 export default class HeadTag extends React.Component {
@@ -30,7 +29,9 @@ export default class HeadTag extends React.Component {
     return (
       <Consumer>
         {headTags => {
-          invariant(headTags, '<HeadProvider /> should be in the tree');
+          if (headTags == null) {
+            throw Error('<HeadProvider /> should be in the tree');
+          }
 
           this.headTags = headTags;
 

--- a/tests/ReactDOMMock.js
+++ b/tests/ReactDOMMock.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import invariant from 'tiny-invariant';
 
 export default jest.mock('react-dom', () => ({
   createPortal: (children, element) => {
-    invariant(children, 'portal children should be provided');
-    invariant(
-      element === document.head,
-      'portal element should be document.head'
-    );
+    if (children == null) {
+      throw Error('portal children should be provided');
+    }
+    if (element !== document.head) {
+      throw Error('portal element should be document.head');
+    }
     const Portal = `portal-${element.tagName.toLowerCase()}`;
     return <Portal>{children}</Portal>;
   },


### PR DESCRIPTION
I used invariant and warning packages a lot lately. And after coming back
to the code with them I found myself confused on which codition
invariant/warning is happened.

I suggest to use explicit conditions and simple throw Error inside.