### PR TITLE
Expose component for <base> tag

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/index.umd.js": {
-    "bundled": 8051,
-    "minified": 3469,
-    "gzipped": 1423
+    "bundled": 8200,
+    "minified": 3533,
+    "gzipped": 1432
   },
   "dist/index.min.js": {
-    "bundled": 8051,
-    "minified": 3469,
-    "gzipped": 1423
+    "bundled": 8200,
+    "minified": 3533,
+    "gzipped": 1432
   },
   "dist/index.cjs.js": {
-    "bundled": 6704,
-    "minified": 3556,
-    "gzipped": 1274
+    "bundled": 6841,
+    "minified": 3653,
+    "gzipped": 1290
   },
   "dist/index.esm.js": {
-    "bundled": 6336,
-    "minified": 3258,
-    "gzipped": 1182,
+    "bundled": 6452,
+    "minified": 3336,
+    "gzipped": 1194,
     "treeshaked": {
       "rollup": {
         "code": 305,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add react-head
 1.  You wrap your App with `<HeadProvider />`
 1.  From the server, you pass `headTags[]` array to `<HeadProvider />`
 1.  Then call `renderToStaticMarkup(headTags)` and include in the `<head />` block of your server template
-1.  To insert head tags within your app, just render one of `<Title />`, `<Meta />`, `<Style />` and `<Link />` components as often as needed.
+1.  To insert head tags within your app, just render one of `<Title />`, `<Meta />`, `<Style />`, `<Link />`, and `<Base />` components as often as needed.
 
 On the server, the tags are collected in the `headTags[]` array, and then on the client the server-generated tags are removed in favor of the client-rendered tags so that SPAs still work as expected (e.g. in cases where subsequent page loads need to change the head tags).
 

--- a/example/src/Home.js
+++ b/example/src/Home.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
-import { Link, Meta, Title, Style } from 'react-head';
+import { Link, Meta, Title, Style, Base } from 'react-head';
 import { Link as RouterLink } from 'react-router-dom';
 import Footer from './Footer';
 import logo from './logo.svg';
@@ -18,6 +18,7 @@ const Home = () => (
     }`}</Style>
     <Link rel="canonical" content="http://jeremygayed.com/" />
     <Meta name="example" content="whatever" />
+    <Base href="/"></Base>
     <div className="Home-header">
       <img src={logo} className="Home-logo" alt="logo" />
       <h2>react-head example</h2>
@@ -31,7 +32,7 @@ const Home = () => (
       Click the example contact page below to see how the Header tags will
       update
     </p>
-    <RouterLink to="/contact">Contact Page</RouterLink>
+    <RouterLink to="contact">Contact Page</RouterLink>
     <Footer />
   </div>
 );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,3 +32,10 @@ export const Meta: React.ComponentType<
 export const Link: React.ComponentType<
   React.LinkHTMLAttributes<HTMLLinkElement>
 >;
+
+/**
+ * <base> tag component
+ */
+export const Base: React.ComponentType<
+  React.BaseHTMLAttributes<HTMLBaseElement>
+>;

--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,6 @@ export const Meta = props => <HeadTag tag="meta" {...props} />;
 
 export const Link = props => <HeadTag tag="link" {...props} />;
 
+export const Base = props => <HeadTag tag="base" {...props} />;
+
 export { default as HeadProvider } from './HeadProvider';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -14,3 +14,5 @@ declare export var Style: React.ComponentType<{ [string]: mixed }>;
 declare export var Meta: React.ComponentType<{ [string]: mixed }>;
 
 declare export var Link: React.ComponentType<{ [string]: mixed }>;
+
+declare export var Base: React.ComponentType<{ [string]: mixed }>;

--- a/src/test_flow.js
+++ b/src/test_flow.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { HeadProvider, Title, Style, Meta, Link } from '../';
+import { HeadProvider, Title, Style, Meta, Link, Base } from '../';
 
 [
   <HeadProvider headTags={[]}>
@@ -21,4 +21,5 @@ import { HeadProvider, Title, Style, Meta, Link } from '../';
   <Style />,
   <Meta />,
   <Link />,
+  <Base />,
 ];

--- a/tests/__snapshots__/dom.test.js.snap
+++ b/tests/__snapshots__/dom.test.js.snap
@@ -17,5 +17,5 @@ exports[`removes head tags added during ssr 2`] = `
       
       
       <not-react-head-element>
-    </not-react-head-element><title>Test title</title><style>body {}</style><link href=\\"index.css\\"><meta charset=\\"utf-8\\">"
+    </not-react-head-element><title>Test title</title><style>body {}</style><link href=\\"index.css\\"><meta charset=\\"utf-8\\"><base href=\\"/new_base\\">"
 `;

--- a/tests/__snapshots__/ssr.test.js.snap
+++ b/tests/__snapshots__/ssr.test.js.snap
@@ -22,6 +22,10 @@ Array [
     charSet="utf-8"
     data-rh=""
   />,
+  <base
+    data-rh=""
+    href="/new_base"
+  />,
 ]
 `;
 

--- a/tests/__snapshots__/web.test.js.snap
+++ b/tests/__snapshots__/web.test.js.snap
@@ -68,6 +68,11 @@ exports[`renders into document.head portal 1`] = `
       charSet="utf-8"
     />
   </portal-head>
+  <portal-head>
+    <base
+      href="/new_base"
+    />
+  </portal-head>
 </div>
 `;
 

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { HeadProvider, Title, Style, Meta, Link } from '../src';
+import { HeadProvider, Title, Style, Meta, Link, Base } from '../src';
 
 test('removes head tags added during ssr', () => {
   const root = document.createElement('div');
@@ -25,6 +25,7 @@ test('removes head tags added during ssr', () => {
         <Style>{`body {}`}</Style>
         <Link href="index.css" />
         <Meta charSet="utf-8" />
+        <Base href="/new_base" />
       </div>
     </HeadProvider>,
     root

--- a/tests/ssr.test.js
+++ b/tests/ssr.test.js
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { HeadProvider, Title, Style, Meta, Link } from '../src';
+import { HeadProvider, Title, Style, Meta, Link, Base } from '../src';
 
 test('renders nothing and adds tags to headTags context array', () => {
   const arr = [];
@@ -16,6 +16,7 @@ test('renders nothing and adds tags to headTags context array', () => {
         <Style>{`body {}`}</Style>
         <Link href="index.css" />
         <Meta charSet="utf-8" />
+        <Base href="/new_base" />
       </div>
     </HeadProvider>
   );

--- a/tests/web.test.js
+++ b/tests/web.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as plug from 'react-powerplug';
 import TestRenderer from 'react-test-renderer';
 import './ReactDOMMock';
-import { HeadProvider, Title, Style, Meta, Link } from '../src';
+import { HeadProvider, Title, Style, Meta, Link, Base } from '../src';
 
 test('renders into document.head portal', () => {
   const renderer = TestRenderer.create(
@@ -13,6 +13,7 @@ test('renders into document.head portal', () => {
         <Style>{`body {}`}</Style>
         <Link href="index.css" />
         <Meta charSet="utf-8" />
+        <Base href="/new_base" />
       </div>
     </HeadProvider>
   );


### PR DESCRIPTION
I'm in a similar situation as @maparent in https://github.com/tizmagik/react-head/issues/102. Managing a `<base>` tag would be useful when when situating an app within a dynamic path. I also considered exposing the `HeadTag` component directly, but according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head#See_also), the only head tags not currently supported are `<base>`, `<script>`, `<noscript>`, and `<template>`, and if you're trying to use react to manage `<script>`, `<noscript>` , or `<template>` tags, you've probably got bigger issues.

So here's a PR that exposes `<base>` tags as a `<Base>` component, complete with documentation, example, and typings.