### PR TITLE
Add explicit `children` prop to `HeadProvider`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ import * as React from 'react';
  */
 export const HeadProvider: React.ComponentType<{
   headTags?: React.ReactElement<unknown>[];
+  children?: React.ReactNode | undefined
 }>;
 
 /**


### PR DESCRIPTION
This issue breaks apps with React 18. Fixes #140